### PR TITLE
Added a simple handler for notice errors

### DIFF
--- a/WTemplate.php
+++ b/WTemplate.php
@@ -208,9 +208,9 @@ class WTemplate {
 		// Buffer
 		ob_start();
 		
-		// Define a soft handler for undfined variables
+		// Define a soft handler for undefined variables
 		set_error_handler(function($errno, $errstr, $errfile, $errline) {
-			echo $errstr;
+			echo str_replace(array('Undefined index: ', 'Undefined variable: '), 'WT!', $errstr);
 		}, E_NOTICE);
 		
 		try { // Critical section


### PR DESCRIPTION
Un petit handler d'erreur pour les variables non déclarées est ajouté dans WTemplate.

Lorsqu'une variable ne peut être trouvé, un simple "Undefined index/variable: variable_name" s'affichera.

Qu'en penses-tu ?
