### PR TITLE
Two new syntaxes for {$var}

### DIFF
--- a/WTemplateCompiler.php
+++ b/WTemplateCompiler.php
@@ -215,6 +215,14 @@ class WTemplateCompiler {
 
 		$var_string = array_shift($functions);
 
+		$var_default = '';
+
+		// Detect if there is a default value for the variable set
+		if (preg_match('/^(.+?)(?:\s+or\s+)(.+?)$/s', $var_string, $matches)) {
+			$var_string = $matches[1];
+			$var_default = $matches[2];
+		}
+
 		$levels = explode('.', $var_string);
 
 		// In {block}, local variables must be used directly
@@ -231,6 +239,11 @@ class WTemplateCompiler {
 			} else {
 				$return .= "['".$s."']";
 			}
+		}
+
+		// Set the default value if there is one
+		if (!empty($var_default)) {
+			$return = '(isset('.$return.') ? '.$return.' : '.$var_default.')';
 		}
 
 		// Functions to apply on the variable

--- a/WTemplateCompiler.php
+++ b/WTemplateCompiler.php
@@ -120,7 +120,19 @@ class WTemplateCompiler {
 		$output = "";
 
 		// Variable display
-		if (strpos($node, '$') === 0) {
+		// Escaped variable
+		if (substr($node, 0, 2) == '!$' && substr($node, -1) == '!') {
+			$node = trim($node, '!');
+
+			if ($inner_node) {
+				// Inner variables will be treated by compilers
+				$output = '{'.$original_node.'}';
+			} else {
+				$output = $this->compile_var($node, true);
+			}
+		}
+		// Non-escaped variables
+		else if (strpos($node, '$') === 0) {
 			if ($inner_node) {
 				// Inner variables will be treated by compilers
 				$output = '{'.$original_node.'}';
@@ -318,13 +330,19 @@ class WTemplateCompiler {
 	/**
 	 * Compiles a variable displaying it.
 	 *
-	 * <code>{$array.index1.index2...|func1|func2...}</code>
+	 * <code>{$array.index1.index2...|func1|func2...}</code> for an unescaped variable
+	 * <code>{!$array.index1.index2...|func1|func2...!}</code> for an escaped variable
 	 *
 	 * @param string $args A string of variables that will be compiled
+	 * @param bool $escaped Tell if the var has to be escaped. Default is false.
 	 * @return string The compiled variables
 	 */
-	public function compile_var($args) {
+	public function compile_var($args, $escaped = false) {
 		if (!empty($args)) {
+			if ($escaped) {
+				return '<?php echo htmlentities('.$this->parseVar($args).'); ?>';
+			}
+
 			return '<?php echo '.$this->parseVar($args).'; ?>';
 		}
 

--- a/WTemplateParser.php
+++ b/WTemplateParser.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * WTemplateParser.php
  */
@@ -66,7 +66,7 @@ class WTemplateParser {
 					if (!$comment) {
 						// Check whether { is backslashed
 						// List of authorized chars to start a node (alphanum, / for closing nodes and $ for var displaying nodes
-						if ($i < $length-1 && preg_match('#[a-zA-Z0-9/$%]#', $string[$i+1]) && $last_char != '\\') {
+						if ($i < $length-1 && preg_match('#[a-zA-Z0-9/$!%]#', $string[$i+1]) && $last_char != '\\') {
 							$level++;
 
 							// Create a new level in the temporary array


### PR DESCRIPTION
This pull request introduces two new syntaxes to WTemplate.

First, the `{$var or 'Default'}` syntax, which is equivalent to the `$var ?? 'Default'` PHP 7 syntax.

This syntax is here to deal with the "WT!VAR" message happening when `$var` is not defined.

Second, the {!$var!} syntax, which is a short tag for {$var|htmlentities}. This tag must be used when echoing a variable in a html attribute, for example :

```html
<input type="text" value="{!$value!}">
```

This ensures that quotes are encoded, so they won't terminate the `value="..."` attribute prematurely.

These two new syntaxes are fully compatible with each other. For example, the following code is correct :

```html
<input type="text" value="{!$value or 'Default'!}">
```