### PR TITLE
Add two compilers for {break ...} and {continue ...}

### DIFF
--- a/WTemplateCompiler.php
+++ b/WTemplateCompiler.php
@@ -463,6 +463,30 @@ class WTemplateCompiler {
 	}
 
 	/**
+	 * Compiles {break [$condition]}
+	 *
+	 * @param string $condition The break condition
+	 * @return string The compiled code
+	 */
+	public function compile_break($condition) {
+		$condition = $this->replaceVars($condition);
+
+		return !empty($condition) ? '<?php if('.$condition.'): break; endif; ?>' : '<?php break; ?>';
+	}
+
+	/**
+	 * Compiles {continue [$condition]}
+	 *
+	 * @param string $condition The continue condition
+	 * @return string The compiled code
+	 */
+	public function compile_continue($condition) {
+		$condition = $this->replaceVars($condition);
+
+		return !empty($condition) ? '<?php if('.$condition.'): continue; endif; ?>' : '<?php continue; ?>';
+	}
+
+	/**
 	 * Compiles {/for}.
 	 *
 	 * @return string The compiled code


### PR DESCRIPTION
This PR adds two new compilers for WTemplate : the `break` and the `continue` statements for the `for` loop.

The syntax is `{break $condition}` (same for continue). The `$condition` parameter is optional. This code also works :

``` php
{if $condition}
    {break}
{/if}
```

Example of code using the break and continue statements :

``` php
{for $index, $person in $persons}
    {continue {$person.id} == 5}

    {$person.name}

    {break {$index} == 5}
{/for}
```
